### PR TITLE
fnarg: Filter function argument with simple C expression

### DIFF
--- a/bpf/btrace.c
+++ b/bpf/btrace.c
@@ -92,6 +92,12 @@ output_fn_args(struct event *event, void *ctx)
     }
 }
 
+static __noinline bool
+filter_fnarg(void *ctx)
+{
+    return ctx != NULL;
+}
+
 static __always_inline int
 emit_btrace_event(void *ctx)
 {
@@ -114,6 +120,8 @@ emit_btrace_event(void *ctx)
 
     event->pid = bpf_get_current_pid_tgid() >> 32;
     if (cfg->pid && event->pid != cfg->pid)
+        return BPF_OK;
+    if (!filter_fnarg(ctx))
         return BPF_OK;
 
     bpf_get_func_ret(ctx, (void *) &retval); /* required 5.17 kernel. */

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/leonhwangprojects/btrace
 
-go 1.23.0
+go 1.23.4
 
 toolchain go1.24.0
 
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/klauspost/compress v1.17.11
 	github.com/knightsc/gapstone v4.0.1+incompatible
+	github.com/leonhwangprojects/bice v0.1.1-0.20250227143508-96c8dbba466f
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.8.0
@@ -21,6 +22,7 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	rsc.io/c2go v0.0.0-20170620140410-520c22818a08 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/leonhwangprojects/bice v0.1.1-0.20250227143508-96c8dbba466f h1:7sUiPGXOBibszJJNN9I7DTCqr6ltW5ox9aNWG0/rHac=
+github.com/leonhwangprojects/bice v0.1.1-0.20250227143508-96c8dbba466f/go.mod h1:NfunBX4+FQmdYOjmjX6g9UH/hR1zyODCLzBV5hO05eA=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -51,3 +53,5 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+rsc.io/c2go v0.0.0-20170620140410-520c22818a08 h1:AAIN5uzUq20OU2cNoPTVljUm7JDaD0Z/+Xl/uMBHJgU=
+rsc.io/c2go v0.0.0-20170620140410-520c22818a08/go.mod h1:hE73EMCiJ3lIDPgEDEK781LZrVhFDxT+I+ziQRoLVNE=

--- a/internal/btrace/bpf_asm.go
+++ b/internal/btrace/bpf_asm.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+func findStartIndex(prog *ebpf.ProgramSpec, stub string) (int, bool) {
+	for i := 0; i < len(prog.Instructions); i++ {
+		if symbol := prog.Instructions[i].Symbol(); symbol == stub {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func findReturnIndex(prog *ebpf.ProgramSpec, start int) (int, bool) {
+	retOpCode := asm.Return().OpCode
+	for i := start; i < len(prog.Instructions); i++ {
+		if prog.Instructions[i].OpCode == retOpCode {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func injectInsns(prog *ebpf.ProgramSpec, stub string, insns asm.Instructions) {
+	injIdx, ok := findStartIndex(prog, stub)
+	if !ok {
+		return
+	}
+
+	retIdx, ok := findReturnIndex(prog, injIdx)
+	if !ok {
+		return
+	}
+
+	if len(insns) != 0 {
+		insns[0] = insns[0].WithMetadata(prog.Instructions[injIdx].Metadata)
+	}
+	prog.Instructions = append(prog.Instructions[:injIdx],
+		append(insns, prog.Instructions[retIdx+1:]...)...)
+}
+
+func clearSubprog(prog *ebpf.ProgramSpec, stub string) {
+	injectInsns(prog, stub, nil)
+
+	for i := 0; i < len(prog.Instructions); i++ {
+		if ref := prog.Instructions[i].Reference(); ref == stub {
+			prog.Instructions[i] = asm.Mov.Imm(asm.R0, 1)
+		}
+	}
+}

--- a/internal/btrace/filter_fnarg.go
+++ b/internal/btrace/filter_fnarg.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"github.com/leonhwangprojects/bice"
+	"github.com/leonhwangprojects/btrace/internal/strx"
+)
+
+const (
+	injectStubFilterArg = "filter_fnarg"
+)
+
+var fnArg funcArgument
+
+type funcArgument struct {
+	expr string
+	name string
+}
+
+func prepareFuncArgument(expr string) funcArgument {
+	var arg funcArgument
+	arg.expr = expr
+
+	for i := 0; i < len(expr); i++ {
+		if !strx.IsChar(expr[i]) {
+			arg.name = expr[:i]
+			break
+		}
+	}
+
+	return arg
+}
+
+func (arg *funcArgument) compile(idx int, t btf.Type) (asm.Instructions, error) {
+	insns, err := bice.SimpleCompile(arg.expr, t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile expression %s: %v", arg.expr, err)
+	}
+
+	return append(asm.Instructions{
+		asm.Mov.Reg(asm.R3, asm.R10),
+		asm.Add.Imm(asm.R3, -8),
+		asm.Mov.Imm(asm.R2, int32(idx)),
+		// r1 is ctx already
+		asm.FnGetFuncArg.Call(),
+		asm.LoadMem(asm.R1, asm.R10, -8, asm.DWord),
+	}, insns...), nil
+}
+
+func (arg *funcArgument) clear(prog *ebpf.ProgramSpec) {
+	clearSubprog(prog, injectStubFilterArg)
+}
+
+func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, idx int, t btf.Type) error {
+	if arg.expr == "" {
+		arg.clear(prog)
+		return nil
+	}
+
+	insns, err := arg.compile(idx, t)
+	if err != nil {
+		return err
+	}
+
+	injectInsns(prog, injectStubFilterArg, insns)
+
+	return nil
+}

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -4,11 +4,7 @@
 package btrace
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	flag "github.com/spf13/pflag"
 )
@@ -30,6 +26,7 @@ var (
 	verbose           bool
 	disasmIntelSyntax bool
 	mode              string
+	filterArg         string
 
 	outputLbr       bool
 	outputFuncStack bool
@@ -38,98 +35,6 @@ var (
 	noColorOutput   bool
 	limitEvents     uint
 )
-
-type ProgFlag struct {
-	progID uint32
-	pinned string
-	tag    string
-	name   string
-	pid    uint32
-
-	descriptor string
-	funcName   string
-
-	all bool
-}
-
-func parseProgFlag(p string) (ProgFlag, error) {
-	var pf ProgFlag
-
-	if p == "*" {
-		pf.all = true
-		return pf, nil
-	}
-
-	id, funcName, ok := strings.Cut(p, ":")
-	switch id {
-	case "i", "id":
-		id, funcName, ok = strings.Cut(funcName, ":")
-		break
-
-	case "p", "pinned":
-		pf.descriptor = progFlagDescriptorPinned
-		pf.pinned, pf.funcName, _ = strings.Cut(funcName, ":")
-		if !fileExists(pf.pinned) {
-			return pf, fmt.Errorf("pinned file %s does not exist", pf.pinned)
-		}
-		return pf, nil
-
-	case "t", "tag":
-		pf.descriptor = progFlagDescriptorTag
-		pf.tag, pf.funcName, _ = strings.Cut(funcName, ":")
-		if pf.tag == "" {
-			return pf, errors.New("tag must not be empty")
-		}
-		return pf, nil
-
-	case "n", "name":
-		pf.descriptor = progFlagDescriptorName
-		pf.name, pf.funcName, _ = strings.Cut(funcName, ":")
-		if pf.name == "" {
-			return pf, errors.New("name must not be empty")
-		}
-		return pf, nil
-
-	case "pid":
-		pf.descriptor = progFlagDescriptorPid
-		id, pf.funcName, _ = strings.Cut(funcName, ":")
-		pid, err := strconv.ParseUint(id, 10, 32)
-		if err != nil {
-			return pf, fmt.Errorf("failed to parse pid %s from %s: %w", funcName, p, err)
-		}
-		pf.pid = uint32(pid)
-		return pf, nil
-
-	default:
-	}
-
-	progID, err := strconv.ParseUint(id, 10, 32)
-	if err != nil {
-		return pf, fmt.Errorf("failed to parse progID %s from %s: %w", id, p, err)
-	}
-
-	pf.descriptor = progFlagDescriptorID
-	pf.progID = uint32(progID)
-	if ok {
-		pf.funcName = funcName
-	}
-
-	return pf, nil
-}
-
-func parseProgsFlag(progs []string) ([]ProgFlag, error) {
-	flags := make([]ProgFlag, 0, len(progs))
-	for _, p := range progs {
-		pf, err := parseProgFlag(p)
-		if err != nil {
-			return nil, err
-		}
-
-		flags = append(flags, pf)
-	}
-
-	return flags, nil
-}
 
 type Flags struct {
 	progs  []string
@@ -157,11 +62,13 @@ func ParseFlags() (*Flags, error) {
 	f.BoolVar(&outputLbr, "output-lbr", false, "output LBR perf event")
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
+	f.StringVar(&filterArg, "filter-arg", "", "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
 
 	err := f.Parse(os.Args)
 
 	noColorOutput = flags.outputFile != "" || !isatty(os.Stdout.Fd())
+	fnArg = prepareFuncArgument(filterArg)
 
 	return &flags, err
 }

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -44,6 +44,8 @@ type Flags struct {
 
 	disasm      bool
 	disasmBytes uint
+
+	showFuncProto bool
 }
 
 func ParseFlags() (*Flags, error) {
@@ -64,6 +66,7 @@ func ParseFlags() (*Flags, error) {
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 	f.StringVar(&filterArg, "filter-arg", "", "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
+	f.BoolVar(&flags.showFuncProto, "show-func-proto", false, "show function prototype of -p,-k")
 
 	err := f.Parse(os.Args)
 
@@ -107,4 +110,8 @@ func (f *Flags) OtherMode() string {
 	}
 
 	return TracingModeExit
+}
+
+func (f *Flags) ShowFuncProto() bool {
+	return f.showFuncProto
 }

--- a/internal/btrace/flags_prog.go
+++ b/internal/btrace/flags_prog.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ProgFlag struct {
+	progID uint32
+	pinned string
+	tag    string
+	name   string
+	pid    uint32
+
+	descriptor string
+	funcName   string
+
+	all bool
+}
+
+func parseProgFlag(p string) (ProgFlag, error) {
+	var pf ProgFlag
+
+	if p == "*" {
+		pf.all = true
+		return pf, nil
+	}
+
+	id, funcName, ok := strings.Cut(p, ":")
+	switch id {
+	case "i", "id":
+		id, funcName, ok = strings.Cut(funcName, ":")
+		break
+
+	case "p", "pinned":
+		pf.descriptor = progFlagDescriptorPinned
+		pf.pinned, pf.funcName, _ = strings.Cut(funcName, ":")
+		if !fileExists(pf.pinned) {
+			return pf, fmt.Errorf("pinned file %s does not exist", pf.pinned)
+		}
+		return pf, nil
+
+	case "t", "tag":
+		pf.descriptor = progFlagDescriptorTag
+		pf.tag, pf.funcName, _ = strings.Cut(funcName, ":")
+		if pf.tag == "" {
+			return pf, errors.New("tag must not be empty")
+		}
+		return pf, nil
+
+	case "n", "name":
+		pf.descriptor = progFlagDescriptorName
+		pf.name, pf.funcName, _ = strings.Cut(funcName, ":")
+		if pf.name == "" {
+			return pf, errors.New("name must not be empty")
+		}
+		return pf, nil
+
+	case "pid":
+		pf.descriptor = progFlagDescriptorPid
+		id, pf.funcName, _ = strings.Cut(funcName, ":")
+		pid, err := strconv.ParseUint(id, 10, 32)
+		if err != nil {
+			return pf, fmt.Errorf("failed to parse pid %s from %s: %w", funcName, p, err)
+		}
+		pf.pid = uint32(pid)
+		return pf, nil
+
+	default:
+	}
+
+	progID, err := strconv.ParseUint(id, 10, 32)
+	if err != nil {
+		return pf, fmt.Errorf("failed to parse progID %s from %s: %w", id, p, err)
+	}
+
+	pf.descriptor = progFlagDescriptorID
+	pf.progID = uint32(progID)
+	if ok {
+		pf.funcName = funcName
+	}
+
+	return pf, nil
+}
+
+func parseProgsFlag(progs []string) ([]ProgFlag, error) {
+	flags := make([]ProgFlag, 0, len(progs))
+	for _, p := range progs {
+		pf, err := parseProgFlag(p)
+		if err != nil {
+			return nil, err
+		}
+
+		flags = append(flags, pf)
+	}
+
+	return flags, nil
+}

--- a/internal/btrace/func_proto.go
+++ b/internal/btrace/func_proto.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/fatih/color"
+	"github.com/leonhwangprojects/btrace/internal/assert"
+	"github.com/leonhwangprojects/btrace/internal/btfx"
+	"golang.org/x/exp/maps"
+)
+
+func showFuncProto(w io.Writer, fn *btf.Func) {
+	clr := color.New(color.FgYellow)
+
+	// func return
+	retDesc := btfx.Repr(fn.Type.(*btf.FuncProto).Return)
+	if retDesc[len(retDesc)-1] == '*' {
+		clr.Fprintf(w, "%s", retDesc)
+	} else {
+		clr.Fprintf(w, "%s ", retDesc)
+	}
+
+	// func name
+	clr.Fprint(w, fn.Name)
+
+	// func params
+	clr.Fprint(w, "(")
+	params := fn.Type.(*btf.FuncProto).Params
+	for i, p := range params {
+		typDesc := btfx.Repr(p.Type)
+		if p.Name != "" {
+			if typDesc[len(typDesc)-1] == '*' {
+				clr.Fprintf(w, "%s%s", typDesc, p.Name)
+			} else {
+				clr.Fprintf(w, "%s %s", typDesc, p.Name)
+			}
+		} else {
+			clr.Fprintf(w, "%s", btfx.Repr(p.Type))
+		}
+		if i != len(params)-1 {
+			clr.Fprint(w, ", ")
+		}
+	}
+	clr.Fprint(w, ");\n")
+}
+
+func ShowFuncProto(f *Flags) {
+	var sb strings.Builder
+
+	haveProg := false
+	if len(f.progs) != 0 {
+		pflags, err := f.ParseProgs()
+		assert.NoErr(err, "Failed to parse bpf prog flags: %v")
+
+		progs, err := NewBPFProgs(pflags, true, true)
+		if len(progs.tracings) != 0 {
+			fmt.Fprint(&sb, "BPF functions:")
+			color.New(color.FgGreen).Fprintf(&sb, " (total %d)\n", len(progs.tracings))
+
+			keys := maps.Keys(progs.tracings)
+			sort.Strings(keys)
+
+			for _, k := range keys {
+				showFuncProto(&sb, progs.tracings[k].fn)
+			}
+
+			haveProg = true
+		}
+	}
+
+	if len(f.kfuncs) != 0 {
+		kallsyms, err := NewKallsyms()
+		assert.NoErr(err, "Failed to read /proc/kallsyms: %v")
+
+		if haveProg {
+			fmt.Fprintln(&sb)
+		}
+
+		kfuncs, err := FindKernelFuncs(f.kfuncs, kallsyms)
+		assert.NoErr(err, "Failed to find kernel functions: %v")
+
+		fmt.Fprint(&sb, "Kernel functions:")
+		color.New(color.FgGreen).Fprintf(&sb, " (total %d)\n", len(kfuncs))
+
+		keys := maps.Keys(kfuncs)
+		slices.Sort(keys)
+
+		for _, k := range keys {
+			showFuncProto(&sb, kfuncs[k].Func)
+		}
+	}
+
+	fmt.Print(sb.String())
+}

--- a/internal/strx/char.go
+++ b/internal/strx/char.go
@@ -1,0 +1,8 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package strx
+
+func IsChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,11 @@ func main() {
 		return
 	}
 
+	if flags.ShowFuncProto() {
+		btrace.ShowFuncProto(flags)
+		return
+	}
+
 	mode := flags.Mode()
 	assert.True(slices.Contains([]string{btrace.TracingModeEntry, btrace.TracingModeExit}, mode),
 		fmt.Sprintf("Mode (%s) must be exit or entry", mode))


### PR DESCRIPTION
Fixes #20 

It will be really useful to filter function argument's attribute when trace kernel functions. Afterward, it's unnecessary to trace all events of the kernel functions.

For example:

```bash
$ sudo ./btrace -k 'bpf_link_init' --filter-arg 'prog->type == BPF_PROG_TYPE_XDP'
2025/03/02 10:21:33 btrace is running..
bpf_link_init args=((struct bpf_link *)link=0xffff991e4b251e40, (enum bpf_link_type)type=BPF_LINK_TYPE_XDP, (const struct bpf_link_ops *)ops=0xffffffff89f6c700, (struct bpf_prog *)prog=0xffffa64a8008d000) retval=(void) cpu=3 process=(336879:fentry_fexit-xd)
```