### PR TITLE
btrace: Introduce session ID

### DIFF
--- a/bpf/btrace.c
+++ b/bpf/btrace.c
@@ -3,6 +3,9 @@
 #include "vmlinux.h"
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#include "bpf_map_helpers.h"
+
+#define BTRACE_MAX_ENTRIES 65536
 
 __u32 ready SEC(".data.ready") = 0;
 
@@ -32,11 +35,25 @@ volatile const struct btrace_config btrace_config = {};
 
 #define MAX_STACK_DEPTH 50
 struct {
-	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
-	__uint(max_entries, 256);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
-} func_stacks SEC(".maps");
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(max_entries, 256);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
+} btrace_stacks SEC(".maps");
+
+struct btrace_str_data {
+    __u8 arg[32];
+    __u8 ret[32];
+};
+
+struct btrace_str_data btrace_str_buff[1] SEC(".data.strs");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, BTRACE_MAX_ENTRIES);
+    __type(key, __u64);
+    __type(value, struct btrace_str_data);
+} btrace_strs SEC(".maps");
 
 struct btrace_fn_arg_data {
     __u64 raw_data;
@@ -45,19 +62,30 @@ struct btrace_fn_arg_data {
 
 struct btrace_fn_data {
     struct btrace_fn_arg_data args[MAX_FN_ARGS];
-    __u8 arg[32];
-    __u8 ret[32];
 };
+
+#define MAX_LBR_ENTRIES 32
+struct btrace_lbr_data {
+    struct perf_branch_entry entries[MAX_LBR_ENTRIES];
+    __s64 nr_bytes;
+};
+
+struct btrace_lbr_data btrace_lbr_buff[1] SEC(".data.lbrs");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, BTRACE_MAX_ENTRIES);
+    __type(key, __u64);
+    __type(value, struct btrace_lbr_data);
+} btrace_lbrs SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 4096<<8);
-} events SEC(".maps");
+} btrace_events SEC(".maps");
 
-#define MAX_LBR_ENTRIES 32
 struct event {
-    struct perf_branch_entry lbr[MAX_LBR_ENTRIES];
-    __s64 nr_bytes;
+    __u64 session_id;
     __s64 func_ret;
     __u64 func_ip;
     __u32 cpu;
@@ -67,11 +95,12 @@ struct event {
     struct btrace_fn_data fn_data;
 } __attribute__((packed));
 
-struct event btrace_events[1] SEC(".data.events");
+struct event btrace_evt_buff[1] SEC(".data.events");
 
 static __always_inline void
-output_fn_args(struct event *event, void *ctx)
+output_fn_data(struct event *event, void *ctx, void *retval, struct btrace_str_data *str)
 {
+    bool is_str, is_number_ptr, use_str = false;
     __u64 arg;
     __u32 i;
 
@@ -85,11 +114,30 @@ output_fn_args(struct event *event, void *ctx)
         if (!arg)
             continue;
 
-        if (cfg->fn_args.args[i].is_str)
-            bpf_probe_read_kernel_str(&event->fn_data.arg, sizeof(event->fn_data.arg), (void *) arg);
-        else if (cfg->fn_args.args[i].is_number_ptr)
+        is_str = cfg->fn_args.args[i].is_str;
+        is_number_ptr = cfg->fn_args.args[i].is_number_ptr;
+        if (is_str) {
+            use_str = true;
+            bpf_probe_read_kernel_str(&str->arg, sizeof(str->arg), (void *) arg);
+        } else if (is_number_ptr) {
             bpf_probe_read_kernel(&event->fn_data.args[i].ptr_data, sizeof(event->fn_data.args[i].ptr_data), (void *) arg);
+        }
     }
+
+    if (cfg->is_ret_str && retval) {
+        use_str = true;
+        bpf_probe_read_kernel_str(&str->ret, sizeof(str->ret), (void *) retval);
+    }
+
+    if (use_str)
+        bpf_map_update_elem(&btrace_strs, &event->session_id, str, BPF_ANY);
+}
+
+static __always_inline void
+output_lbr_data(struct event *event, struct btrace_lbr_data *lbr)
+{
+    if (lbr->nr_bytes > 0)
+        bpf_map_update_elem(&btrace_lbrs, &event->session_id, lbr, BPF_ANY);
 }
 
 static __noinline bool
@@ -98,10 +146,33 @@ filter_fnarg(void *ctx)
     return ctx != NULL;
 }
 
+static __always_inline __u64
+get_tracee_caller_fp(void)
+{
+    u64 fp, fp_caller;
+
+    /* get frame pointer */
+    asm volatile ("%[fp] = r10" : [fp] "+r"(fp) :); /* fp of current bpf prog */
+    (void) bpf_probe_read_kernel(&fp_caller, sizeof(fp_caller), (void *) fp); /* fp of trampoline */
+    (void) bpf_probe_read_kernel(&fp_caller, sizeof(fp_caller), (void *) fp_caller); /* fp of tracee caller */
+    return fp_caller;
+}
+
+static __always_inline __u64
+gen_session_id(void)
+{
+    __u64 fp = get_tracee_caller_fp();
+    __u32 rnd = bpf_get_prandom_u32();
+
+    return ((__u64) rnd) << 32 | (fp & 0xFFFFFFFF);
+}
+
 static __always_inline int
 emit_btrace_event(void *ctx)
 {
-    struct event *event;
+    struct btrace_lbr_data *lbr;
+    struct btrace_str_data *str;
+    struct event *evt;
     __u64 retval;
     __u32 cpu;
 
@@ -109,34 +180,37 @@ emit_btrace_event(void *ctx)
         return BPF_OK;
 
     cpu = bpf_get_smp_processor_id();
-    event = &btrace_events[cpu];
+    lbr = &btrace_lbr_buff[cpu];
+    str = &btrace_str_buff[cpu];
+    evt = &btrace_evt_buff[cpu];
 
     if (cfg->output_lbr)
-        event->nr_bytes = bpf_get_branch_snapshot(event->lbr, sizeof(event->lbr), 0); /* required 5.16 kernel. */
+        lbr->nr_bytes = bpf_get_branch_snapshot(lbr->entries, sizeof(lbr->entries), 0); /* required 5.16 kernel. */
 
     /* Other filters must be after bpf_get_branch_snapshot() to avoid polluting
      * LBR entries.
      */
 
-    event->pid = bpf_get_current_pid_tgid() >> 32;
-    if (cfg->pid && event->pid != cfg->pid)
+    evt->pid = bpf_get_current_pid_tgid() >> 32;
+    if (cfg->pid && evt->pid != cfg->pid)
         return BPF_OK;
     if (!filter_fnarg(ctx))
         return BPF_OK;
 
+    evt->session_id = gen_session_id();
     bpf_get_func_ret(ctx, (void *) &retval); /* required 5.17 kernel. */
-    event->func_ret = retval;
-    event->func_ip = bpf_get_func_ip(ctx); /* required 5.17 kernel. */
-    event->cpu = cpu;
-    bpf_get_current_comm(event->comm, sizeof(event->comm));
-    event->func_stack_id = -1;
+    evt->func_ret = retval;
+    evt->func_ip = bpf_get_func_ip(ctx); /* required 5.17 kernel. */
+    evt->cpu = cpu;
+    bpf_get_current_comm(evt->comm, sizeof(evt->comm));
+    evt->func_stack_id = -1;
     if (cfg->output_stack)
-        event->func_stack_id = bpf_get_stackid(ctx, &func_stacks, BPF_F_FAST_STACK_CMP);
-    output_fn_args(event, ctx);
-    if (cfg->is_ret_str && retval)
-        bpf_probe_read_kernel_str(&event->fn_data.ret, sizeof(event->fn_data.ret), (void *) retval);
+        evt->func_stack_id = bpf_get_stackid(ctx, &btrace_stacks, BPF_F_FAST_STACK_CMP);
+    output_fn_data(evt, ctx, (void *) retval, str);
+    if (cfg->output_lbr)
+        output_lbr_data(evt, lbr);
 
-    bpf_ringbuf_output(&events, event, sizeof(*event), 0);
+    bpf_ringbuf_output(&btrace_events, evt, sizeof(*evt), 0);
 
     return BPF_OK;
 }

--- a/bpf/headers/bpf_map_helpers.h
+++ b/bpf/headers/bpf_map_helpers.h
@@ -1,0 +1,35 @@
+#ifndef __BPF_MAP_HELPERS_H_
+#define __BPF_MAP_HELPERS_H_
+
+#include "vmlinux.h"
+#include "bpf_helpers.h"
+#include "errno.h"
+
+static __always_inline void *
+bpf_map_lookup_or_try_init(void *map, const void *key, const void *init)
+{
+    void *val;
+    long err;
+
+    val = bpf_map_lookup_elem(map, key);
+    if (val)
+        return val;
+
+    err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
+    if (err && err != -EEXIST)
+        return 0;
+
+    return bpf_map_lookup_elem(map, key);
+}
+
+static __always_inline void *
+bpf_map_lookup_and_delete(void *map, const void *key)
+{
+    void *val = bpf_map_lookup_elem(map, key);
+    if (val)
+        bpf_map_delete_elem(map, key);
+
+    return val;
+}
+
+#endif // __BPF_MAP_HELPERS_H_

--- a/internal/btrace/btrace_maps.go
+++ b/internal/btrace/btrace_maps.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+
+	"github.com/leonhwangprojects/btrace/internal/assert"
+)
+
+func PrepareBPFMaps(spec *ebpf.CollectionSpec) map[string]*ebpf.Map {
+	numCPU, err := ebpf.PossibleCPU()
+	assert.NoErr(err, "Failed to get possible cpu: %v")
+
+	lbrsMapSpec := spec.Maps[".data.lbrs"]
+	lbrsMapSpec.Flags |= unix.BPF_F_MMAPABLE
+	lbrsMapSpec.ValueSize = uint32(unsafe.Sizeof(LbrData{})) * uint32(numCPU)
+	lbrsMapSpec.Contents[0].Value = make([]byte, lbrsMapSpec.ValueSize)
+	lbrsData, err := ebpf.NewMap(lbrsMapSpec)
+	assert.NoErr(err, "Failed to create lbrs map: %v")
+
+	lbrs, err := ebpf.NewMap(spec.Maps["btrace_lbrs"])
+	assert.NoErr(err, "Failed to create btrace_lbrs map: %v")
+
+	strsMapSpec := spec.Maps[".data.strs"]
+	strsMapSpec.Flags |= unix.BPF_F_MMAPABLE
+	strsMapSpec.ValueSize = uint32(unsafe.Sizeof(StrData{})) * uint32(numCPU)
+	strsMapSpec.Contents[0].Value = make([]byte, strsMapSpec.ValueSize)
+	strsData, err := ebpf.NewMap(strsMapSpec)
+	assert.NoErr(err, "Failed to create strs map: %v")
+
+	strs, err := ebpf.NewMap(spec.Maps["btrace_strs"])
+	assert.NoErr(err, "Failed to create btrace_strs map: %v")
+
+	stacks, err := ebpf.NewMap(spec.Maps["btrace_stacks"])
+	assert.NoErr(err, "Failed to create btrace_stacks map: %v")
+
+	readyDataMapSpec := spec.Maps[".data.ready"]
+	readyDataMapSpec.Flags |= unix.BPF_F_MMAPABLE
+	readyData, err := ebpf.NewMap(readyDataMapSpec)
+	assert.NoErr(err, "Failed to create ready data map: %v")
+
+	evsMapSpec := spec.Maps[".data.events"]
+	evsMapSpec.Flags |= unix.BPF_F_MMAPABLE
+	evsMapSpec.ValueSize = uint32(unsafe.Sizeof(Event{})) * uint32(numCPU)
+	evsMapSpec.Contents[0].Value = make([]byte, evsMapSpec.ValueSize)
+	evsData, err := ebpf.NewMap(evsMapSpec)
+	assert.NoErr(err, "Failed to create events data map: %v")
+
+	events, err := ebpf.NewMap(spec.Maps["btrace_events"])
+	assert.NoErr(err, "Failed to create events map: %v")
+
+	return map[string]*ebpf.Map{
+		"btrace_events": events,
+		"btrace_lbrs":   lbrs,
+		"btrace_strs":   strs,
+		".data.events":  evsData,
+		".data.lbrs":    lbrsData,
+		".data.strs":    strsData,
+		".data.ready":   readyData,
+		"btrace_stacks": stacks,
+	}
+}
+
+func CloseBPFMaps(maps map[string]*ebpf.Map) {
+	for _, m := range maps {
+		_ = m.Close()
+	}
+}


### PR DESCRIPTION
In order to reduce some unused data in event, separate lbr data and str data from event. Afterward, in userspace, retreive lbr data and str data on demand.

Between event and lbr/str data, it uses a unique session ID to connect them:
1. Event keeps the session ID.
2. `btrace_lbrs` map uses session ID as key to store lbr data.
3. `btrace_strs` map uses session ID as key to store str data.