### PR TITLE
kfuncs: Filter kernel functions by argument

### DIFF
--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -10,14 +10,6 @@ import (
 )
 
 const (
-	progFlagDescriptorID     = "id"
-	progFlagDescriptorPinned = "pinned"
-	progFlagDescriptorTag    = "tag"
-	progFlagDescriptorName   = "name"
-	progFlagDescriptorPid    = "pid"
-)
-
-const (
 	TracingModeEntry = "entry"
 	TracingModeExit  = "exit"
 )

--- a/internal/btrace/flags_kfunc.go
+++ b/internal/btrace/flags_kfunc.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KfuncFlag struct {
+	name string
+	arg  string
+	typ  string
+}
+
+func parseKfuncFlag(k string) (KfuncFlag, error) {
+	var kf KfuncFlag
+
+	fields := strings.Split(k, ":")
+	switch len(fields) {
+	case 1:
+		kf.name = strings.TrimSpace(fields[0])
+
+	case 2:
+		kf.name = strings.TrimSpace(fields[0])
+		kf.arg = strings.TrimSpace(fields[1])
+
+	case 3:
+		kf.name = strings.TrimSpace(fields[0])
+		kf.arg = strings.TrimSpace(fields[1])
+		kf.typ = strings.TrimSpace(fields[2])
+
+	default:
+		return kf, fmt.Errorf("invalid kfunc flag: %s", k)
+	}
+
+	return kf, nil
+}
+
+func parseKfuncFlags(kfs []string) ([]KfuncFlag, error) {
+	var kflags []KfuncFlag
+	for _, k := range kfs {
+		kf, err := parseKfuncFlag(k)
+		if err != nil {
+			return nil, err
+		}
+		kflags = append(kflags, kf)
+	}
+
+	return kflags, nil
+}

--- a/internal/btrace/flags_prog.go
+++ b/internal/btrace/flags_prog.go
@@ -10,6 +10,14 @@ import (
 	"strings"
 )
 
+const (
+	progFlagDescriptorID     = "id"
+	progFlagDescriptorPinned = "pinned"
+	progFlagDescriptorTag    = "tag"
+	progFlagDescriptorName   = "name"
+	progFlagDescriptorPid    = "pid"
+)
+
 type ProgFlag struct {
 	progID uint32
 	pinned string

--- a/internal/btrace/kernel_functions_match.go
+++ b/internal/btrace/kernel_functions_match.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/gobwas/glob"
+
+	"github.com/leonhwangprojects/btrace/internal/btfx"
+)
+
+type kfuncMatch struct {
+	flag KfuncFlag
+	glob glob.Glob
+}
+
+func kfuncFlags2matches(funcs []string) ([]*kfuncMatch, error) {
+	kflags, err := parseKfuncFlags(funcs)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]*kfuncMatch, 0, len(kflags))
+	for _, kf := range kflags {
+		g, err := glob.Compile(kf.name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile glob from %s: %w", kf.name, err)
+		}
+
+		matches = append(matches, &kfuncMatch{
+			flag: kf,
+			glob: g,
+		})
+	}
+
+	return matches, nil
+}
+
+func (m kfuncMatch) match(fn string, fp *btf.FuncProto) bool {
+	if !m.glob.Match(fn) {
+		return false
+	}
+
+	if m.flag.arg == "" {
+		return true
+	}
+
+	for _, p := range fp.Params {
+		if p.Name == m.flag.arg {
+			if m.flag.typ == "" {
+				return true
+			}
+
+			ptyp := btfx.Repr(p.Type)
+			return ptyp == m.flag.typ
+		}
+	}
+
+	return false
+}
+
+func matchKfunc(fn string, fp *btf.FuncProto, matches []*kfuncMatch) bool {
+	for _, m := range matches {
+		if m.match(fn, fp) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #17 

1. Filter by argument name only: `--kfunc '*:skb'`
2. Filter by argument name alongside its type: `--kfunc '*:sk:struct sock *'`