### PR TITLE
pkt: Output packet tuple info

### DIFF
--- a/bpf/btrace.c
+++ b/bpf/btrace.c
@@ -9,6 +9,7 @@
 #include "btrace_lbr.h"
 #include "btrace_arg.h"
 #include "btrace_pkt_filter.h"
+#include "btrace_pkt_output.h"
 
 __u32 ready SEC(".data.ready") = 0;
 
@@ -59,6 +60,7 @@ emit_btrace_event(void *ctx)
 {
     struct btrace_lbr_data *lbr;
     struct btrace_str_data *str;
+    struct btrace_pkt_data *pkt;
     struct event *evt;
     __u64 retval;
     __u32 cpu;
@@ -68,6 +70,7 @@ emit_btrace_event(void *ctx)
 
     cpu = bpf_get_smp_processor_id();
     lbr = &btrace_lbr_buff[cpu];
+    pkt = &btrace_pkt_buff[cpu];
     str = &btrace_str_buff[cpu];
     evt = &btrace_evt_buff[cpu];
 
@@ -97,6 +100,8 @@ emit_btrace_event(void *ctx)
     output_fn_data(evt, ctx, (void *) retval, str);
     if (cfg->output_lbr)
         output_lbr_data(lbr, evt->session_id);
+    if (cfg->output_pkt)
+        output_pkt_tuple(ctx, pkt, evt->session_id);
 
     bpf_ringbuf_output(&btrace_events, evt, sizeof(*evt), 0);
 

--- a/bpf/btrace.h
+++ b/bpf/btrace.h
@@ -22,8 +22,9 @@ struct btrace_fn_args {
 struct btrace_config {
     __u32 output_lbr:1;
     __u32 output_stack:1;
+    __u32 output_pkt:1;
     __u32 is_ret_str:1;
-    __u32 pad:29;
+    __u32 pad:28;
     __u32 pid;
 
     struct btrace_fn_args fn_args;

--- a/bpf/btrace_pkt_output.h
+++ b/bpf/btrace_pkt_output.h
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+
+#ifndef __BTRACE_PKT_OUTPUT_H_
+#define __BTRACE_PKT_OUTPUT_H_
+
+#include "vmlinux.h"
+#include "bpf_helpers.h"
+#include "bpf_endian.h"
+#include "bpf_core_read.h"
+
+#include "btrace.h"
+#include "if_ether.h"
+
+struct btrace_pkt_data {
+    __u64 addrs;
+    __u32 ports;
+    __u8 protocol;
+    __u8 tcp_flags;
+    __u8 pad[2];
+};
+
+struct btrace_pkt_data btrace_pkt_buff[1] SEC(".data.pkts");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, BTRACE_MAX_ENTRIES);
+    __type(key, __u64);
+    __type(value, struct btrace_pkt_data);
+} btrace_pkts SEC(".maps");
+
+static __always_inline void
+output_tuple(struct btrace_pkt_data *pkt, __u64 session_id, struct iphdr *iph)
+{
+    struct udphdr *udp;
+    struct tcphdr *tcp;
+    __u8 b;
+
+    (void) bpf_probe_read_kernel(&b, sizeof(b), (void *) iph);
+    if (((b >> 4) & 0x7) != 4)
+        return;
+
+    switch (BPF_CORE_READ(iph, protocol)) {
+    case IPPROTO_TCP:
+        (void) bpf_probe_read_kernel(&pkt->addrs, sizeof(pkt->addrs), (void *) (&iph->saddr));
+        tcp = (void *) iph + ((b & 0x7) << 2);
+        (void) bpf_probe_read_kernel(&pkt->ports, sizeof(pkt->ports), (void *) (&tcp->source));
+        pkt->protocol = IPPROTO_TCP;
+        (void) bpf_probe_read_kernel(&pkt->tcp_flags, sizeof(pkt->tcp_flags), (void *) (&tcp->window) - 1);
+        break;
+
+    case IPPROTO_UDP:
+        (void) bpf_probe_read_kernel(&pkt->addrs, sizeof(pkt->addrs), (void *) (&iph->saddr));
+        udp = (void *) iph + ((b & 0x7) << 2);
+        (void) bpf_probe_read_kernel(&pkt->ports, sizeof(pkt->ports), (void *) (&udp->source));
+        pkt->protocol = IPPROTO_UDP;
+        break;
+
+    case IPPROTO_ICMP:
+        (void) bpf_probe_read_kernel(&pkt->addrs, sizeof(pkt->addrs), (void *) (&iph->saddr));
+        pkt->protocol = IPPROTO_ICMP;
+        break;
+
+    default:
+        return;
+    }
+
+    (void) bpf_map_update_elem(&btrace_pkts, &session_id, pkt, BPF_ANY);
+}
+
+static __noinline void
+output_skb_tuple(struct btrace_pkt_data *pkt, __u64 session_id, void *ptr)
+{
+    struct sk_buff *skb;
+    struct iphdr *iph;
+    void *head;
+
+    skb = (typeof(skb)) ptr;
+    head = BPF_CORE_READ(skb, head);
+    iph = (typeof(iph)) (head + BPF_CORE_READ(skb, network_header));
+
+    output_tuple(pkt, session_id, iph);
+}
+
+static __noinline void
+output_xdp_tuple(struct btrace_pkt_data *pkt, __u64 session_id, void *ptr)
+{
+    struct xdp_buff *xdp;
+    struct vlan_hdr *vh;
+    struct ethhdr *eth;
+    struct iphdr *iph;
+    void *data;
+
+    xdp = (typeof(xdp)) ptr;
+    data = BPF_CORE_READ(xdp, data);
+    eth = (typeof(eth)) data;
+
+    switch (BPF_CORE_READ(eth, h_proto)) {
+    case bpf_htons(ETH_P_IP):
+        iph = (typeof(iph))(void *) (eth + 1);
+        break;
+
+    case bpf_htons(ETH_P_8021Q):
+        vh = (typeof(vh))(void *) (eth + 1);
+        if (BPF_CORE_READ(vh, h_vlan_encapsulated_proto) != bpf_htons(ETH_P_IP))
+            return;
+        iph = (typeof(iph))(void *) (vh + 1);
+        break;
+
+    default:
+        return;
+    }
+
+    output_tuple(pkt, session_id, iph);
+}
+
+static __noinline void
+output_pkt_tuple(void *ctx, struct btrace_pkt_data *pkt, __u64 session_id)
+{
+    /* This function will be rewrote by Go totally. */
+    void *ptr = (void *) session_id;
+
+    return ctx ? output_skb_tuple(pkt, session_id, ptr) : output_xdp_tuple(pkt, session_id, ptr);
+}
+
+#endif // __BTRACE_PKT_OUTPUT_H_

--- a/bpf/headers/if_ether.h
+++ b/bpf/headers/if_ether.h
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/*
+ * INET		An implementation of the TCP/IP protocol suite for the LINUX
+ *		operating system.  INET is implemented using the  BSD Socket
+ *		interface as the means of communication with the user level.
+ *
+ *		Global definitions for the Ethernet IEEE 802.3 interface.
+ *
+ * Version:	@(#)if_ether.h	1.0.1a	02/08/94
+ *
+ * Author:	Fred N. van Kempen, <waltje@uWalt.NL.Mugnet.ORG>
+ *		Donald Becker, <becker@super.org>
+ *		Alan Cox, <alan@lxorguk.ukuu.org.uk>
+ *		Steve Whitehouse, <gw7rrm@eeshack3.swan.ac.uk>
+ *
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
+ */
+
+#ifndef _UAPI_LINUX_IF_ETHER_H
+#define _UAPI_LINUX_IF_ETHER_H
+
+/*
+ *	IEEE 802.3 Ethernet magic constants.  The frame sizes omit the preamble
+ *	and FCS/CRC (frame check sequence).
+ */
+
+#define ETH_ALEN	6		/* Octets in one ethernet addr	 */
+#define ETH_TLEN	2		/* Octets in ethernet type field */
+#define ETH_HLEN	14		/* Total octets in header.	 */
+#define ETH_ZLEN	60		/* Min. octets in frame sans FCS */
+#define ETH_DATA_LEN	1500		/* Max. octets in payload	 */
+#define ETH_FRAME_LEN	1514		/* Max. octets in frame sans FCS */
+#define ETH_FCS_LEN	4		/* Octets in the FCS		 */
+
+#define ETH_MIN_MTU	68		/* Min IPv4 MTU per RFC791	*/
+#define ETH_MAX_MTU	0xFFFFU		/* 65535, same as IP_MAX_MTU	*/
+
+/*
+ *	These are the defined Ethernet Protocol ID's.
+ */
+
+#define ETH_P_LOOP	0x0060		/* Ethernet Loopback packet	*/
+#define ETH_P_PUP	0x0200		/* Xerox PUP packet		*/
+#define ETH_P_PUPAT	0x0201		/* Xerox PUP Addr Trans packet	*/
+#define ETH_P_TSN	0x22F0		/* TSN (IEEE 1722) packet	*/
+#define ETH_P_ERSPAN2	0x22EB		/* ERSPAN version 2 (type III)	*/
+#define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
+#define ETH_P_X25	0x0805		/* CCITT X.25			*/
+#define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
+#define	ETH_P_BPQ	0x08FF		/* G8BPQ AX.25 Ethernet Packet	[ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_IEEEPUP	0x0a00		/* Xerox IEEE802.3 PUP packet */
+#define ETH_P_IEEEPUPAT	0x0a01		/* Xerox IEEE802.3 PUP Addr Trans packet */
+#define ETH_P_BATMAN	0x4305		/* B.A.T.M.A.N.-Advanced packet [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_DEC       0x6000          /* DEC Assigned proto           */
+#define ETH_P_DNA_DL    0x6001          /* DEC DNA Dump/Load            */
+#define ETH_P_DNA_RC    0x6002          /* DEC DNA Remote Console       */
+#define ETH_P_DNA_RT    0x6003          /* DEC DNA Routing              */
+#define ETH_P_LAT       0x6004          /* DEC LAT                      */
+#define ETH_P_DIAG      0x6005          /* DEC Diagnostics              */
+#define ETH_P_CUST      0x6006          /* DEC Customer use             */
+#define ETH_P_SCA       0x6007          /* DEC Systems Comms Arch       */
+#define ETH_P_TEB	0x6558		/* Trans Ether Bridging		*/
+#define ETH_P_RARP      0x8035		/* Reverse Addr Res packet	*/
+#define ETH_P_ATALK	0x809B		/* Appletalk DDP		*/
+#define ETH_P_AARP	0x80F3		/* Appletalk AARP		*/
+#define ETH_P_8021Q	0x8100          /* 802.1Q VLAN Extended Header  */
+#define ETH_P_ERSPAN	0x88BE		/* ERSPAN type II		*/
+#define ETH_P_IPX	0x8137		/* IPX over DIX			*/
+#define ETH_P_IPV6	0x86DD		/* IPv6 over bluebook		*/
+#define ETH_P_PAUSE	0x8808		/* IEEE Pause frames. See 802.3 31B */
+#define ETH_P_SLOW	0x8809		/* Slow Protocol. See 802.3ad 43B */
+#define ETH_P_WCCP	0x883E		/* Web-cache coordination protocol
+					 * defined in draft-wilson-wrec-wccp-v2-00.txt */
+#define ETH_P_MPLS_UC	0x8847		/* MPLS Unicast traffic		*/
+#define ETH_P_MPLS_MC	0x8848		/* MPLS Multicast traffic	*/
+#define ETH_P_ATMMPOA	0x884c		/* MultiProtocol Over ATM	*/
+#define ETH_P_PPP_DISC	0x8863		/* PPPoE discovery messages     */
+#define ETH_P_PPP_SES	0x8864		/* PPPoE session messages	*/
+#define ETH_P_LINK_CTL	0x886c		/* HPNA, wlan link local tunnel */
+#define ETH_P_ATMFATE	0x8884		/* Frame-based ATM Transport
+					 * over Ethernet
+					 */
+#define ETH_P_PAE	0x888E		/* Port Access Entity (IEEE 802.1X) */
+#define ETH_P_PROFINET	0x8892		/* PROFINET			*/
+#define ETH_P_REALTEK	0x8899          /* Multiple proprietary protocols */
+#define ETH_P_AOE	0x88A2		/* ATA over Ethernet		*/
+#define ETH_P_ETHERCAT	0x88A4		/* EtherCAT			*/
+#define ETH_P_8021AD	0x88A8          /* 802.1ad Service VLAN		*/
+#define ETH_P_802_EX1	0x88B5		/* 802.1 Local Experimental 1.  */
+#define ETH_P_PREAUTH	0x88C7		/* 802.11 Preauthentication */
+#define ETH_P_TIPC	0x88CA		/* TIPC 			*/
+#define ETH_P_LLDP	0x88CC		/* Link Layer Discovery Protocol */
+#define ETH_P_MRP	0x88E3		/* Media Redundancy Protocol	*/
+#define ETH_P_MACSEC	0x88E5		/* 802.1ae MACsec */
+#define ETH_P_8021AH	0x88E7          /* 802.1ah Backbone Service Tag */
+#define ETH_P_MVRP	0x88F5          /* 802.1Q MVRP                  */
+#define ETH_P_1588	0x88F7		/* IEEE 1588 Timesync */
+#define ETH_P_NCSI	0x88F8		/* NCSI protocol		*/
+#define ETH_P_PRP	0x88FB		/* IEC 62439-3 PRP/HSRv0	*/
+#define ETH_P_CFM	0x8902		/* Connectivity Fault Management */
+#define ETH_P_FCOE	0x8906		/* Fibre Channel over Ethernet  */
+#define ETH_P_IBOE	0x8915		/* Infiniband over Ethernet	*/
+#define ETH_P_TDLS	0x890D          /* TDLS */
+#define ETH_P_FIP	0x8914		/* FCoE Initialization Protocol */
+#define ETH_P_80221	0x8917		/* IEEE 802.21 Media Independent Handover Protocol */
+#define ETH_P_HSR	0x892F		/* IEC 62439-3 HSRv1	*/
+#define ETH_P_NSH	0x894F		/* Network Service Header */
+#define ETH_P_LOOPBACK	0x9000		/* Ethernet loopback packet, per IEEE 802.3 */
+#define ETH_P_QINQ1	0x9100		/* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ2	0x9200		/* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ3	0x9300		/* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_EDSA	0xDADA		/* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_DSA_8021Q	0xDADB		/* Fake VLAN Header for DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_DSA_A5PSW	0xE001		/* A5PSW Tag Value [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_IFE	0xED3E		/* ForCES inter-FE LFB type */
+#define ETH_P_AF_IUCV   0xFBFB		/* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
+
+#define ETH_P_802_3_MIN	0x0600		/* If the value in the ethernet type is more than this value
+					 * then the frame is Ethernet II. Else it is 802.3 */
+
+/*
+ *	Non DIX types. Won't clash for 1500 types.
+ */
+
+#define ETH_P_802_3	0x0001		/* Dummy type for 802.3 frames  */
+#define ETH_P_AX25	0x0002		/* Dummy protocol id for AX.25  */
+#define ETH_P_ALL	0x0003		/* Every packet (be careful!!!) */
+#define ETH_P_802_2	0x0004		/* 802.2 frames 		*/
+#define ETH_P_SNAP	0x0005		/* Internal only		*/
+#define ETH_P_DDCMP     0x0006          /* DEC DDCMP: Internal only     */
+#define ETH_P_WAN_PPP   0x0007          /* Dummy type for WAN PPP frames*/
+#define ETH_P_PPP_MP    0x0008          /* Dummy type for PPP MP frames */
+#define ETH_P_LOCALTALK 0x0009		/* Localtalk pseudo type 	*/
+#define ETH_P_CAN	0x000C		/* CAN: Controller Area Network */
+#define ETH_P_CANFD	0x000D		/* CANFD: CAN flexible data rate*/
+#define ETH_P_CANXL	0x000E		/* CANXL: eXtended frame Length */
+#define ETH_P_PPPTALK	0x0010		/* Dummy type for Atalk over PPP*/
+#define ETH_P_TR_802_2	0x0011		/* 802.2 frames 		*/
+#define ETH_P_MOBITEX	0x0015		/* Mobitex (kaz@cafe.net)	*/
+#define ETH_P_CONTROL	0x0016		/* Card specific control frames */
+#define ETH_P_IRDA	0x0017		/* Linux-IrDA			*/
+#define ETH_P_ECONET	0x0018		/* Acorn Econet			*/
+#define ETH_P_HDLC	0x0019		/* HDLC frames			*/
+#define ETH_P_ARCNET	0x001A		/* 1A for ArcNet :-)            */
+#define ETH_P_DSA	0x001B		/* Distributed Switch Arch.	*/
+#define ETH_P_TRAILER	0x001C		/* Trailer switch tagging	*/
+#define ETH_P_PHONET	0x00F5		/* Nokia Phonet frames          */
+#define ETH_P_IEEE802154 0x00F6		/* IEEE802.15.4 frame		*/
+#define ETH_P_CAIF	0x00F7		/* ST-Ericsson CAIF protocol	*/
+#define ETH_P_XDSA	0x00F8		/* Multiplexed DSA protocol	*/
+#define ETH_P_MAP	0x00F9		/* Qualcomm multiplexing and
+					 * aggregation protocol
+					 */
+#define ETH_P_MCTP	0x00FA		/* Management component transport
+					 * protocol packets
+					 */
+
+#endif /* _UAPI_LINUX_IF_ETHER_H */

--- a/internal/btrace/bpf_get_func_arg.go
+++ b/internal/btrace/bpf_get_func_arg.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import "github.com/cilium/ebpf/asm"
+
+func genGetFuncArg(index int, dst asm.Register) asm.Instructions {
+	return asm.Instructions{
+		asm.Mov.Reg(asm.R3, asm.R10),
+		asm.Add.Imm(asm.R3, -8),
+		asm.Mov.Imm(asm.R2, int32(index)),
+		asm.FnGetFuncArg.Call(),
+		asm.LoadMem(dst, asm.R10, -8, asm.DWord),
+	}
+}

--- a/internal/btrace/bpf_spec.go
+++ b/internal/btrace/bpf_spec.go
@@ -16,5 +16,9 @@ func TrimSpec(spec *ebpf.CollectionSpec) {
 		if fnArg.expr == "" {
 			fnArg.clear(prog)
 		}
+
+		if !outputPkt {
+			pktOutput.clear(prog)
+		}
 	}
 }

--- a/internal/btrace/btrace_config.go
+++ b/internal/btrace/btrace_config.go
@@ -6,6 +6,7 @@ package btrace
 const (
 	lbrConfigFlagOutputLbrIdx = 0 + iota
 	lbrConfigFlagOutputStackIdx
+	lbrConfigFlagOutputPktIdx
 	lbrConfigFlagIsRetStrIdx
 )
 
@@ -25,6 +26,12 @@ func (cfg *BtraceConfig) SetOutputLbr(v bool) {
 func (cfg *BtraceConfig) SetOutputStack(v bool) {
 	if v {
 		cfg.Flags |= 1 << lbrConfigFlagOutputStackIdx
+	}
+}
+
+func (cfg *BtraceConfig) SetOutputPktTuple(v bool) {
+	if v {
+		cfg.Flags |= 1 << lbrConfigFlagOutputPktIdx
 	}
 }
 

--- a/internal/btrace/btrace_maps.go
+++ b/internal/btrace/btrace_maps.go
@@ -36,6 +36,16 @@ func PrepareBPFMaps(spec *ebpf.CollectionSpec) map[string]*ebpf.Map {
 	strs, err := ebpf.NewMap(spec.Maps["btrace_strs"])
 	assert.NoErr(err, "Failed to create btrace_strs map: %v")
 
+	pktsMapSpec := spec.Maps[".data.pkts"]
+	pktsMapSpec.Flags |= unix.BPF_F_MMAPABLE
+	pktsMapSpec.ValueSize = uint32(unsafe.Sizeof(StrData{})) * uint32(numCPU)
+	pktsMapSpec.Contents[0].Value = make([]byte, pktsMapSpec.ValueSize)
+	pktsData, err := ebpf.NewMap(pktsMapSpec)
+	assert.NoErr(err, "Failed to create pkts map: %v")
+
+	pkts, err := ebpf.NewMap(spec.Maps["btrace_pkts"])
+	assert.NoErr(err, "Failed to create btrace_pkts map: %v")
+
 	stacks, err := ebpf.NewMap(spec.Maps["btrace_stacks"])
 	assert.NoErr(err, "Failed to create btrace_stacks map: %v")
 
@@ -58,9 +68,11 @@ func PrepareBPFMaps(spec *ebpf.CollectionSpec) map[string]*ebpf.Map {
 		"btrace_events": events,
 		"btrace_lbrs":   lbrs,
 		"btrace_strs":   strs,
+		"btrace_pkts":   pkts,
 		".data.events":  evsData,
 		".data.lbrs":    lbrsData,
 		".data.strs":    strsData,
+		".data.pkts":    pktsData,
 		".data.ready":   readyData,
 		"btrace_stacks": stacks,
 	}

--- a/internal/btrace/btrace_pkt.go
+++ b/internal/btrace/btrace_pkt.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+var be = binary.BigEndian
+
+type PktData struct {
+	Addrs [8]byte
+	Ports [4]byte
+	Proto byte
+	TCPFl byte
+	Pad   [2]byte
+}
+
+func (p *PktData) zero() bool {
+	return p.Addrs == [8]byte{}
+}
+
+func (p *PktData) saddr() netip.Addr {
+	return netip.AddrFrom4(([4]byte)(p.Addrs[:4]))
+}
+
+func (p *PktData) daddr() netip.Addr {
+	return netip.AddrFrom4(([4]byte)(p.Addrs[4:]))
+}
+
+func (p *PktData) sport() uint16 {
+	return be.Uint16(p.Ports[:2])
+}
+
+func (p *PktData) dport() uint16 {
+	return be.Uint16(p.Ports[2:])
+}
+
+func (p *PktData) tcpFlags() string {
+	tcpFlags := []string{
+		"FIN",
+		"SYN",
+		"RST",
+		"PSH",
+		"ACK",
+		"URG",
+		"ECE",
+		"CWR",
+	}
+
+	var flags []string
+	for i, flag := range tcpFlags {
+		if p.TCPFl&(1<<uint(i)) != 0 {
+			flags = append(flags, flag)
+		}
+	}
+
+	return strings.Join(flags, "|")
+}
+
+func (p *PktData) repr() string {
+	var sb strings.Builder
+
+	switch p.Proto {
+	case unix.IPPROTO_TCP:
+		fmt.Fprintf(&sb, "%s:%d -> %s:%d (TCP:%s)", p.saddr(), p.sport(), p.daddr(), p.dport(), p.tcpFlags())
+
+	case unix.IPPROTO_UDP:
+		fmt.Fprintf(&sb, "%s:%d -> %s:%d (UDP)", p.saddr(), p.sport(), p.daddr(), p.dport())
+
+	case unix.IPPROTO_ICMP:
+		fmt.Fprintf(&sb, "%s -> %s (ICMP)", p.saddr(), p.daddr())
+
+	default:
+		return "..UNK.."
+	}
+
+	return sb.String()
+}

--- a/internal/btrace/filter_fnarg.go
+++ b/internal/btrace/filter_fnarg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 	"github.com/leonhwangprojects/bice"
+
 	"github.com/leonhwangprojects/btrace/internal/strx"
 )
 
@@ -55,7 +56,7 @@ func (arg *funcArgument) compile(idx int, t btf.Type) (asm.Instructions, error) 
 }
 
 func (arg *funcArgument) clear(prog *ebpf.ProgramSpec) {
-	clearSubprog(prog, injectStubFilterArg)
+	clearFilterSubprog(prog, injectStubFilterArg)
 }
 
 func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, idx int, t btf.Type) error {

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -23,6 +23,7 @@ var (
 
 	outputLbr       bool
 	outputFuncStack bool
+	outputPkt       bool
 	filterPid       uint32
 	kfuncAllKmods   bool
 	noColorOutput   bool
@@ -56,6 +57,7 @@ func ParseFlags() (*Flags, error) {
 	f.StringVarP(&mode, "mode", "m", TracingModeExit, "mode of btrace, exit or entry")
 	f.BoolVar(&outputLbr, "output-lbr", false, "output LBR perf event")
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
+	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 	f.StringVar(&filterArg, "filter-arg", "", "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
 	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")

--- a/internal/btrace/output_pkt.go
+++ b/internal/btrace/output_pkt.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+const (
+	outputPktTupleFunc = "output_pkt_tuple"
+	outputSkbTupleFunc = "output_skb_tuple"
+	outputXdpTupleFunc = "output_xdp_tuple"
+)
+
+var pktOutput packetOutput
+
+type packetOutput struct{}
+
+func (p *packetOutput) injectStub(prog *ebpf.ProgramSpec, index int, stub, other string) {
+	clearOutputSubprog(prog, other)
+
+	// R1: ctx
+	// R2: pkt data
+	// R3: session ID
+
+	insns := asm.Instructions{
+		asm.Mov.Reg(asm.R6, asm.R2), // R6 = pkt data
+		asm.Mov.Reg(asm.R7, asm.R3), // R7 = session ID
+	}
+	insns = append(insns, genGetFuncArg(index, asm.R3)...) // R3 = skb/xdp
+	insns = append(insns, asm.Instructions{
+		asm.Mov.Reg(asm.R2, asm.R7), // R2 = session ID
+		asm.Mov.Reg(asm.R1, asm.R6), // R1 = pkt data
+		asm.Call.Label(stub),        // call stub()
+		asm.Return(),
+	}...)
+
+	injectInsns(prog, outputPktTupleFunc, insns)
+}
+
+func (p *packetOutput) outputSkb(prog *ebpf.ProgramSpec, index int) {
+	p.injectStub(prog, index, outputSkbTupleFunc, outputXdpTupleFunc)
+}
+
+func (p *packetOutput) outputXdp(prog *ebpf.ProgramSpec, index int) {
+	p.injectStub(prog, index, outputXdpTupleFunc, outputSkbTupleFunc)
+}
+
+func (p *packetOutput) clear(prog *ebpf.ProgramSpec) {
+	clearOutputSubprog(prog, outputPktTupleFunc)
+	clearOutputSubprog(prog, outputSkbTupleFunc)
+	clearOutputSubprog(prog, outputXdpTupleFunc)
+}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/leonhwangprojects/btrace/internal/btrace"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang btrace ./bpf/btrace.c -- -g -D__TARGET_ARCH_x86 -I./bpf/headers -I./lib/libbpf/src -Wall
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang btrace ./bpf/btrace.c -- -g -D__TARGET_ARCH_x86 -I./bpf -I./bpf/headers -I./lib/libbpf/src -Wall
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang feat ./bpf/feature.c -- -g -D__TARGET_ARCH_x86 -I./bpf/headers -I./lib/libbpf/src -Wall
 
 func main() {


### PR DESCRIPTION
Fixes #32 

If `--output-pkt` and tracee has skb/xdp argument, btrace is able to output the tuple info of skb/xdp's packet data.

For example:

```bash
$ sudo ./btrace -k tcp_v4_rcv --filter-pkt 'tcp and host 1.1.1.1' --output-pkt
2025/03/07 13:05:17 btrace is running..
tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50400) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:SYN|ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef51d00) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50900) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:PSH|ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50900) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef51e00) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50500) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50400) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:PSH|ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50000) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50600) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:PSH|ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef51b00) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:PSH|ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef51e00) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50a00) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:ACK)

tcp_v4_rcv args=((struct sk_buff *)skb=0xffff991f1ef50300) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:42232 (TCP:FIN|PSH|ACK)
```