### PR TITLE
fnarg: Filter multiple arguments

### DIFF
--- a/internal/btrace/bpf_spec.go
+++ b/internal/btrace/bpf_spec.go
@@ -13,8 +13,8 @@ func TrimSpec(spec *ebpf.CollectionSpec) {
 			pktFilter.clear(prog)
 		}
 
-		if fnArg.expr == "" {
-			fnArg.clear(prog)
+		if len(fnArgs) == 0 {
+			clearFilterArgSubprog(prog)
 		}
 
 		if !outputPkt {

--- a/internal/btrace/bpf_tracing.go
+++ b/internal/btrace/bpf_tracing.go
@@ -114,19 +114,17 @@ func TracingProgName(mode string) string {
 }
 
 func (t *bpfTracing) injectFnArg(prog *ebpf.ProgramSpec, params []btf.FuncParam, fnName string) error {
-	if fnArg.expr == "" {
+	if len(fnArgs) == 0 {
 		return nil
 	}
 
 	for i, p := range params {
-		if p.Name != fnArg.name {
-			continue
-		}
-		if fnArg.typ != "" && fnArg.typ != btfx.Repr(p.Type) {
+		arg, ok := matchFuncArgs(p)
+		if !ok {
 			continue
 		}
 
-		err := fnArg.inject(prog, i, p.Type)
+		err := arg.inject(prog, i, p.Type)
 		if err != nil {
 			return fmt.Errorf("failed to inject func arg filter expr: %w", err)
 		}
@@ -232,6 +230,7 @@ func (t *bpfTracing) injectPktOutput(prog *ebpf.ProgramSpec, params []btf.FuncPa
 			DebugLog("Injected --output-pkt to %dth param %s of %s", i, p.Name, fnName)
 			return
 		}
+
 	}
 }
 

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -16,6 +16,7 @@ const (
 
 var (
 	verbose           bool
+	debugLog          bool
 	disasmIntelSyntax bool
 	mode              string
 	filterArg         string
@@ -54,6 +55,7 @@ func ParseFlags() (*Flags, error) {
 	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, 0 to guess it automatically")
 	f.BoolVar(&disasmIntelSyntax, "disasm-intel-syntax", false, "use Intel asm syntax for disasm, ATT asm syntax by default")
 	f.BoolVarP(&verbose, "verbose", "v", false, "output verbose log")
+	f.BoolVar(&debugLog, "debug-log", false, "output many debug logs")
 	f.StringVarP(&mode, "mode", "m", TracingModeExit, "mode of btrace, exit or entry")
 	f.BoolVar(&outputLbr, "output-lbr", false, "output LBR perf event")
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
@@ -63,6 +65,8 @@ func ParseFlags() (*Flags, error) {
 	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
 	f.BoolVar(&flags.showFuncProto, "show-func-proto", false, "show function prototype of -p,-k")
+
+	f.MarkHidden("debug-log")
 
 	err := f.Parse(os.Args)
 

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -19,7 +19,7 @@ var (
 	debugLog          bool
 	disasmIntelSyntax bool
 	mode              string
-	filterArg         string
+	filterArg         []string
 	filterPkt         string
 
 	outputLbr       bool
@@ -61,7 +61,7 @@ func ParseFlags() (*Flags, error) {
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
 	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
-	f.StringVar(&filterArg, "filter-arg", "", "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
+	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
 	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
 	f.BoolVar(&flags.showFuncProto, "show-func-proto", false, "show function prototype of -p,-k")
@@ -71,7 +71,7 @@ func ParseFlags() (*Flags, error) {
 	err := f.Parse(os.Args)
 
 	noColorOutput = flags.outputFile != "" || !isatty(os.Stdout.Fd())
-	fnArg = prepareFuncArgument(filterArg)
+	fnArgs = prepareFuncArguments(filterArg)
 	pktFilter = preparePacketFilter(filterPkt)
 
 	return &flags, err

--- a/internal/btrace/log.go
+++ b/internal/btrace/log.go
@@ -10,3 +10,9 @@ func VerboseLog(format string, args ...interface{}) {
 		log.Printf(format, args...)
 	}
 }
+
+func DebugLog(format string, args ...any) {
+	if debugLog {
+		log.Printf(format, args...)
+	}
+}


### PR DESCRIPTION
It's to support multiple `--filter-arg`s. Afterwards, as for different arguments, it is able to inject the corresponding filter expression.

For example, `--filter-arg '(struct sk_buff *)skb->hash != 0' --filter-arg '(struct sock *)sk->__sk_common.skc_dport == 443'`, it will inject `skb->hash != 0` when tracee has argument named `skb` and typed `struct sk_buff *`, and inject `sk->__sk_common.skc_dport == 443` when tracee has argument named `sk` and typed `struct sock *`.

However, if tracee has both `skb` and `sk`, the very first `--filter-arg` will be injected.

Meanwhile, fix getting name from expression for `--filter-arg`.