### PR TITLE
fnarg: Relax arg limit from 6 to 12

### DIFF
--- a/bpf/btrace.c
+++ b/bpf/btrace.c
@@ -64,6 +64,7 @@ emit_btrace_event(void *ctx)
     struct btrace_str_data *str;
     struct btrace_pkt_data *pkt;
     struct event *evt;
+    size_t event_sz;
     __u64 retval;
     __u32 cpu;
 
@@ -107,7 +108,9 @@ emit_btrace_event(void *ctx)
     if (cfg->output_pkt)
         output_pkt_tuple(ctx, pkt, evt->session_id);
 
-    bpf_ringbuf_output(&btrace_events, evt, sizeof(*evt), 0);
+    event_sz  = offsetof(struct event, fn_data);
+    event_sz += sizeof(struct btrace_fn_arg_data) * cfg->fn_args.nr_fn_args;
+    bpf_ringbuf_output(&btrace_events, evt, event_sz, 0);
 
     return BPF_OK;
 }

--- a/bpf/btrace.h
+++ b/bpf/btrace.h
@@ -50,6 +50,10 @@ struct event {
     __u32 pid;
     __u8 comm[16];
     __s64 func_stack_id;
+
+    /* fn_data must be the last attr of event in order to output arg data on
+     * demand.
+     */
     struct btrace_fn_data fn_data;
 } __attribute__((packed));
 

--- a/bpf/btrace.h
+++ b/bpf/btrace.h
@@ -13,7 +13,7 @@ struct btrace_fn_arg_flags {
     bool is_str;
 };
 
-#define MAX_FN_ARGS 6
+#define MAX_FN_ARGS 12
 struct btrace_fn_args {
     struct btrace_fn_arg_flags args[MAX_FN_ARGS];
     __u32 nr_fn_args;

--- a/internal/btrace/bpf_kfuncs.go
+++ b/internal/btrace/bpf_kfuncs.go
@@ -83,7 +83,7 @@ func detectTraceable(spec *ebpf.CollectionSpec, addrs []uintptr) ([]uintptr, err
 	return nontraceables, nil
 }
 
-func DetectTraceable(spec *ebpf.CollectionSpec, kfuncs KFuncs) (KFuncs, error) {
+func detectTraceables(spec *ebpf.CollectionSpec, kfuncs KFuncs, silent bool) (KFuncs, error) {
 	addrs := maps.Keys(kfuncs)
 	slices.Sort(addrs)
 
@@ -103,10 +103,14 @@ func DetectTraceable(spec *ebpf.CollectionSpec, kfuncs KFuncs) (KFuncs, error) {
 		}
 
 		for _, nt := range nontraceables {
-			VerboseLog("Skip non-traceable kernel function %s", kfuncs[nt].Ksym.name)
+			verboseLogIf(!silent, "Skip non-traceable kernel function %s", kfuncs[nt].Ksym.name)
 			delete(kfuncs, nt)
 		}
 	}
 
 	return kfuncs, nil
+}
+
+func DetectTraceable(spec *ebpf.CollectionSpec, kfuncs KFuncs) (KFuncs, error) {
+	return detectTraceables(spec, kfuncs, false)
 }

--- a/internal/btrace/bpf_prog_info.go
+++ b/internal/btrace/bpf_prog_info.go
@@ -110,7 +110,7 @@ func newBPFProgInfo(prog *ebpf.Program) (*bpfProgInfo, error) {
 		info.kaddrRange.end = info.kaddrRange.start + uintptr(funcLen)
 		info.funcName = strings.TrimSpace(funcInfos[i].Func.Name)
 		info.funcProto = funcInfos[i].Func
-		info.funcParams = getFuncParams(funcInfos[i].Func)
+		info.funcParams, _ /* won't fail for bpf progs */ = getFuncParams(funcInfos[i].Func)
 
 		for i, kaddr := range jitedLineInfos {
 			if info.kaddrRange.start <= uintptr(kaddr) && uintptr(kaddr) < info.kaddrRange.end {

--- a/internal/btrace/bpf_tracing.go
+++ b/internal/btrace/bpf_tracing.go
@@ -39,7 +39,7 @@ func setBtraceConfig(spec *ebpf.CollectionSpec, args []FuncParamFlags, isRetStr 
 	cfg.FilterPid = filterPid
 	cfg.FnArgsNr = uint32(len(args))
 	for i, arg := range args {
-		cfg.FnArgs[i] = arg
+		cfg.FnArgs[i] = arg.ParamFlags
 	}
 
 	if err := spec.Variables["btrace_config"].Set(cfg); err != nil {

--- a/internal/btrace/btrace.go
+++ b/internal/btrace/btrace.go
@@ -117,7 +117,7 @@ func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *K
 			return fmt.Errorf("failed to read ringbuf: %w", err)
 		}
 
-		if len(record.RawSample) < int(unsafe.Sizeof(Event{})) {
+		if len(record.RawSample) < int(unsafe.Sizeof(Event{}))-int(unsafe.Sizeof(FnData{})) {
 			continue
 		}
 

--- a/internal/btrace/btrace_config.go
+++ b/internal/btrace/btrace_config.go
@@ -13,7 +13,7 @@ const (
 type BtraceConfig struct {
 	Flags     uint32
 	FilterPid uint32
-	FnArgs    [MAX_BPF_FUNC_ARGS]FuncParamFlags
+	FnArgs    [MAX_BPF_FUNC_ARGS]ParamFlags
 	FnArgsNr  uint32
 }
 

--- a/internal/btrace/func_proto.go
+++ b/internal/btrace/func_proto.go
@@ -84,7 +84,7 @@ func ShowFuncProto(f *Flags) {
 			fmt.Fprintln(&sb)
 		}
 
-		kfuncs, err := FindKernelFuncs(f.kfuncs, kallsyms)
+		kfuncs, err := findKernelFuncs(f.kfuncs, kallsyms, MAX_BPF_FUNC_ARGS, false, true)
 		assert.NoErr(err, "Failed to find kernel functions: %v")
 
 		fmt.Fprint(&sb, "Kernel functions:")

--- a/internal/btrace/kernel_functions_max_arg.go
+++ b/internal/btrace/kernel_functions_max_arg.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/exp/maps"
+)
+
+func DetectSupportedMaxArg(traceableSpec, spec *ebpf.CollectionSpec, ksyms *Kallsyms) (int, error) {
+	kfuncs, err := findKernelFuncs([]string{"ip_*", "tcp_*"}, ksyms, MAX_BPF_FUNC_ARGS, true, true)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find kernel functions with many args: %w", err)
+	}
+
+	kfuncs, err = detectTraceables(traceableSpec, kfuncs, true)
+	if err != nil {
+		return 0, fmt.Errorf("failed to detect traceable kernel functions: %w", err)
+	}
+	if len(kfuncs) == 0 {
+		return 0, fmt.Errorf("no traceable kernel functions found")
+	}
+
+	spec = spec.Copy()
+	err = setBtraceConfig(spec, nil, false)
+	if err != nil {
+		return 0, fmt.Errorf("failed to set btrace config: %w", err)
+	}
+
+	reusedMaps := PrepareBPFMaps(spec)
+	defer CloseBPFMaps(reusedMaps)
+
+	prog := spec.Programs[TracingProgName(mode)]
+	pktFilter.clear(prog)
+	pktOutput.clear(prog)
+	clearFilterArgSubprog(prog)
+
+	attachType := ebpf.AttachTraceFExit
+	if mode == TracingModeEntry {
+		attachType = ebpf.AttachTraceFEntry
+	}
+
+	kfunc := maps.Values(kfuncs)[0]
+	prog.AttachTo = kfunc.Ksym.name
+	prog.AttachType = attachType
+	DebugLog("Using %s to detect max arg", kfunc.Name())
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		MapReplacements: reusedMaps,
+	})
+	if err != nil {
+		var verr *ebpf.VerifierError
+		if errors.As(err, &verr) {
+			DebugLog("Verifier log:\n%+v", verr)
+		}
+		DebugLog("Failed to create max-arg detection bpf collection: %v", err)
+		return MAX_BPF_FUNC_ARGS_PREV, nil
+	}
+	defer coll.Close()
+
+	return MAX_BPF_FUNC_ARGS, nil
+}

--- a/internal/btrace/log.go
+++ b/internal/btrace/log.go
@@ -11,6 +11,12 @@ func VerboseLog(format string, args ...interface{}) {
 	}
 }
 
+func verboseLogIf(cond bool, format string, args ...interface{}) {
+	if cond && verbose {
+		log.Printf(format, args...)
+	}
+}
+
 func DebugLog(format string, args ...any) {
 	if debugLog {
 		log.Printf(format, args...)


### PR DESCRIPTION
Fixes #29 

Since commit https://github.com/torvalds/linux/commit/473e3150e30a ("bpf, x86: allow function arguments up to 12 for TRACING")
v6.6 kernel, bpf is able to get the 6/7/8/9/10/11th argument by
`bpf_get_func_arg()` helper. Afterwards, `btrace` is able to fetch these
arguments if kernel supports it.

e.g.

```bash
$ sudo ./btrace -k 'tcp_select_*'
tcp_select_initial_window args=((const struct sock *)sk=0xffff991eeab69bc0, (int)__space=33280, (__u32)mss=0x5b4/1460, (__u32 *)rcv_wnd=0xffff991eeab6a260(0x7d78/32120), (__u32 *)window_clamp=0xffff991eeab6a244(0x7fff80/8388480), (int)wscale_ok=1, (__u8 *)rcv_wscale=0xffffa64a80a6fbc7(0x7/7), (__u32)init_rcv_wnd=0x0/0) retval=(void) cpu=5 process=(479102:curl)
```

At the same time, `btrace` has to represent the value of the argument
whose type is struct or union.

For example:

```bash
$ sudo ./btrace -k 'bpf_prog_load' --limit-events 20
bpf_prog_load args=((union bpf_attr *)attr=0xffffa64a809fbe20, (bpfptr_t)uattr={{kernel=0xc00021f5e0,user=0xc00021f5e0},is_kernel=..BITFIELD..}, (u32)uattr_size=0x90/144, ) retval=(int)-9 cpu=7 process=(476941:fentry_fexit-xd)
```

As for x86 ABI, the argument, whose size is larger than 8B, occupies two
registers in the function call. See the above `uattr` argument.