### PR TITLE
fnarg: Represent value of bitfield

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.0
 
 require (
 	github.com/Asphaltt/addr2line v0.1.1
-	github.com/Asphaltt/mybtf v0.0.0-20250214152135-9b78e6e206e7
+	github.com/Asphaltt/mybtf v0.0.0-20250313140353-0c2e5e870741
 	github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a
 	github.com/fatih/color v1.18.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Asphaltt/addr2line v0.1.1 h1:eYkAgT9clEjzYMVeTY3dF0dFjX5gc97yWuoGHmvq
 github.com/Asphaltt/addr2line v0.1.1/go.mod h1:02z/FcEJ9rsH1i7It81L6xHtjSoBOrKbDtTGlptzfP0=
 github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7 h1:z1Ohf61MSfgVMxAs2Z4nWZ4p+a12K/u41JJurdIxdBU=
 github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7/go.mod h1:1K5hEzsMBLTPdRJKEHqBFJ8Zt2VRqDhomcQ11KH0WW4=
-github.com/Asphaltt/mybtf v0.0.0-20250214152135-9b78e6e206e7 h1:F3HT6v6BsAwvXpnDtxwKDhdzI9h2s3N+K0VmZL9CZXc=
-github.com/Asphaltt/mybtf v0.0.0-20250214152135-9b78e6e206e7/go.mod h1:ZxswciFofS8TXGsc2j5CWCY8O3XwKEysCnU7hoI1fnI=
+github.com/Asphaltt/mybtf v0.0.0-20250313140353-0c2e5e870741 h1:uRWTbgVR+jERhz9w2Y0mAi+uJ+fp/OzXuV/p7on/yhY=
+github.com/Asphaltt/mybtf v0.0.0-20250313140353-0c2e5e870741/go.mod h1:ZxswciFofS8TXGsc2j5CWCY8O3XwKEysCnU7hoI1fnI=
 github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a h1:Gwqct80mVVFXishYmIJKmnkSxSUsPIkoEHpLagVHIjU=
 github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a/go.mod h1:z4P4PotUQMhVXjjIj1zZUD7KogbAIS/o6WtXnM8QG9U=
 github.com/cloudflare/cbpfc v0.0.0-20230809125630-31aa294050ff h1:SLLG1soGN/PYTXkYWiR1PAxWlP1URBvgZPYymC5+0WI=

--- a/internal/btfx/types.go
+++ b/internal/btfx/types.go
@@ -223,7 +223,7 @@ func reprMember(sb *strings.Builder, m *btf.Member, data []byte, find findSymbol
 		fmt.Fprintf(sb, "%s=", m.Name)
 	}
 	if m.BitfieldSize != 0 {
-		fmt.Fprintf(sb, "..BITFIELD..")
+		fmt.Fprintf(sb, mybtf.DumpBitfield(m.Offset, m.BitfieldSize, data))
 	} else {
 		fmt.Fprintf(sb, "%s", ReprValue(m.Type, *(*uint64)(unsafe.Pointer(&data[m.Offset])), *(*uint64)(unsafe.Pointer(&data[m.Offset+8])), find))
 	}


### PR DESCRIPTION
Fixes #39 

With `mybtf.DumpBitfield()`, `btrace` is able to represent value of bitfield easily.

e.g.

```bash
$ sudo ./btrace -k 'bpf_prog_load'
bpf_prog_load args=((union bpf_attr *)attr=0xffffa64a80a9fde0, (bpfptr_t)uattr={{kernel=0x7fff215af150,user=0x7fff215af150},is_kernel=0x0}, (u32)uattr_size=0x90/144) retval=(int)4 cpu=5 process=(480818:bpftrace)
```