### PR TITLE
btrace: Support trace tp_btf

### DIFF
--- a/internal/btrace/bpf_link.go
+++ b/internal/btrace/bpf_link.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package btrace
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+type bpfLinkInfo struct {
+	progID     ebpf.ProgramID
+	attachType ebpf.AttachType
+	isTracing  bool
+}
+
+type bpfLinks struct {
+	links map[ebpf.ProgramID]bpfLinkInfo
+}
+
+func newBPFLinks() (*bpfLinks, error) {
+	var links bpfLinks
+	links.links = make(map[ebpf.ProgramID]bpfLinkInfo)
+
+	var iter link.Iterator
+	for iter.Next() {
+		info, err := iter.Link.Info()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get link info of link ID %d: %w", iter.ID, err)
+		}
+
+		tracing := info.Tracing()
+		if tracing == nil {
+			continue
+		}
+
+		links.links[info.Program] = bpfLinkInfo{
+			progID:     info.Program,
+			attachType: ebpf.AttachType(tracing.AttachType),
+			isTracing:  true,
+		}
+	}
+
+	return &links, nil
+}

--- a/internal/btrace/bpf_prog.go
+++ b/internal/btrace/bpf_prog.go
@@ -17,6 +17,8 @@ type bpfProgs struct {
 
 	tracings map[string]bpfTracingInfo // id:func -> prog, func
 
+	links *bpfLinks
+
 	disasm bool // disassemble BPF programs instead of tracing them
 }
 
@@ -34,6 +36,11 @@ func NewBPFProgs(pflags []ProgFlag, onlyPrepare, disasm bool) (*bpfProgs, error)
 			progs.Close()
 		}
 	}()
+
+	progs.links, err = newBPFLinks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare bpf links info: %w", err)
+	}
 
 	err = progs.prepareProgInfos(pflags)
 	if err != nil {


### PR DESCRIPTION
From view of kernel bpf verifier, only these attach-types, fentry and fexit, cannot be traced by fentry/fexit. Therefore, the tracing progs with other attach-type can be traced by fentry/fexit, e.g. tp_btf.

```c
// kernel/bpf/verifier.c

int bpf_check_attach_target(struct bpf_verifier_log *log,
			    const struct bpf_prog *prog,
			    const struct bpf_prog *tgt_prog,
			    u32 btf_id,
			    struct bpf_attach_target_info *tgt_info)
{
	// ...
		if (prog_tracing) {
			if (aux->attach_tracing_prog) {
				/*
				 * Target program is an fentry/fexit which is already attached
				 * to another tracing program. More levels of nesting
				 * attachment are not allowed.
				 */
				bpf_log(log, "Cannot nest tracing program attach more than once\n");
				return -EINVAL;
			}
		}
	// ...
}

// kernel/bpf/syscall.c

static int bpf_prog_load(union bpf_attr *attr, bpfptr_t uattr, u32 uattr_size)
{
	// ...
	/*
	 * Bookkeeping for managing the program attachment chain.
	 *
	 * It might be tempting to set attach_tracing_prog flag at the attachment
	 * time, but this will not prevent from loading bunch of tracing prog
	 * first, then attach them one to another.
	 *
	 * The flag attach_tracing_prog is set for the whole program lifecycle, and
	 * doesn't have to be cleared in bpf_tracing_link_release, since tracing
	 * programs cannot change attachment target.
	 */
	if (type == BPF_PROG_TYPE_TRACING && dst_prog &&
	    dst_prog->type == BPF_PROG_TYPE_TRACING) {
		prog->aux->attach_tracing_prog = true;
	}
	// ...
}
```