### PR TITLE
disasm: Find symbol info from kmod dbgsym

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 toolchain go1.24.0
 
 require (
-	github.com/Asphaltt/addr2line v0.1.1
+	github.com/Asphaltt/addr2line v0.1.2
 	github.com/Asphaltt/mybtf v0.0.0-20250315135407-f9d09086616b
 	github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Asphaltt/addr2line v0.1.1 h1:eYkAgT9clEjzYMVeTY3dF0dFjX5gc97yWuoGHmvqAYc=
-github.com/Asphaltt/addr2line v0.1.1/go.mod h1:02z/FcEJ9rsH1i7It81L6xHtjSoBOrKbDtTGlptzfP0=
+github.com/Asphaltt/addr2line v0.1.2 h1:GPZflkxPeF+7EKXt9ty8GDwBhd7tVxQilUkCHI/4Ujg=
+github.com/Asphaltt/addr2line v0.1.2/go.mod h1:02z/FcEJ9rsH1i7It81L6xHtjSoBOrKbDtTGlptzfP0=
 github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7 h1:z1Ohf61MSfgVMxAs2Z4nWZ4p+a12K/u41JJurdIxdBU=
 github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7/go.mod h1:1K5hEzsMBLTPdRJKEHqBFJ8Zt2VRqDhomcQ11KH0WW4=
 github.com/Asphaltt/mybtf v0.0.0-20250315135407-f9d09086616b h1:LRS0ckDlNnX2Bux8k0HqLVf/2PqvvykoB8HSxXf7XjA=

--- a/internal/btrace/dump.go
+++ b/internal/btrace/dump.go
@@ -55,7 +55,7 @@ func DumpProg(pf []ProgFlag) {
 
 		VerboseLog("Creating addr2line from vmlinux ..")
 		kaslr := NewKaslr(kallsyms.Stext(), textAddr)
-		addr2line, err = NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF())
+		addr2line, err = NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF(), kallsyms.Stext())
 		assert.NoErr(err, "Failed to create addr2line: %v")
 	}
 

--- a/internal/btrace/flags.go
+++ b/internal/btrace/flags.go
@@ -28,6 +28,7 @@ var (
 	outputPkt       bool
 	filterPid       uint32
 	kfuncAllKmods   bool
+	kfuncKmods      []string
 	noColorOutput   bool
 	limitEvents     uint
 )
@@ -51,6 +52,7 @@ func ParseFlags() (*Flags, error) {
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for btrace in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced if '*' is specified")
 	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions by shell wildcards way")
 	f.BoolVar(&kfuncAllKmods, "kfunc-all-kmods", false, "filter functions in all kernel modules")
+	f.StringSliceVar(&kfuncKmods, "kfunc-kmods", nil, "filter functions in specified kernel modules")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
 	f.BoolVarP(&flags.disasm, "disasm", "d", false, "disasm bpf prog or kernel function")
 	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, 0 to guess it automatically")

--- a/internal/btrace/kaslr.go
+++ b/internal/btrace/kaslr.go
@@ -19,6 +19,14 @@ func (k *Kaslr) effectiveAddr(kaddr uint64) uint64 {
 	return uint64(kaddr + (k.saddr - k.kaddr))
 }
 
+func (k *Kaslr) revertAddr(saddr uint64) uint64 {
+	if k.saddr < k.kaddr {
+		return saddr + (k.kaddr - k.saddr)
+	}
+
+	return saddr - (k.saddr - k.kaddr)
+}
+
 func (k *Kaslr) offset() uint64 {
 	if k.saddr < k.kaddr {
 		return k.kaddr - k.saddr

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 
 		btrace.VerboseLog("Creating addr2line from vmlinux ..")
 		kaslr := btrace.NewKaslr(kallsyms.Stext(), textAddr)
-		addr2line, err = btrace.NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF())
+		addr2line, err = btrace.NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF(), kallsyms.Stext())
 		assert.NoErr(err, "Failed to create addr2line: %v")
 	}
 


### PR DESCRIPTION
When kernel module does not register its symbols to `/proc/kallsyms`, `btrace` is unable to disasm the symbols of the kernel module.

Therefore, `btrace` has to find the kernel addresses for the symbols based on its dbgsym. Next, `btrace` can disasm the kernel addresses by its way.

`--kfunc-kmods` is required to provide the specified kernel module name.