### PR TITLE
fnarg: Reduce one insn for outputing multi args

### DIFF
--- a/internal/btrace/output_arg.go
+++ b/internal/btrace/output_arg.go
@@ -248,12 +248,12 @@ func (arg *argDataOutput) injectArgs(args []funcArgumentOutput) asm.Instructions
 	)
 
 	for i, a := range args {
-		insns = append(insns, a.insn...)
 		if i != 0 {
 			insns = append(insns,
 				asm.Mov.Reg(asm.R1, asm.R8), // R1 = ctx
 			)
 		}
+		insns = append(insns, a.insn...)
 	}
 
 	insns = append(insns,


### PR DESCRIPTION
It's a code logic issue that produces an useless `r1 = r8` insn.

Fix it by generating `r1 = r8` when necessary.